### PR TITLE
Extra Protections for GearDatabase and CardDatabase

### DIFF
--- a/Assets/Scripts/Cards/CardDatabase.cs
+++ b/Assets/Scripts/Cards/CardDatabase.cs
@@ -110,9 +110,38 @@ public static class CardDatabase
         CardData[] cardsLoaded = Resources.LoadAll<CardData>(folder);
         foreach (CardData cardasset in cardsLoaded)
         {
-            allCards.Add(cardasset.cardID, cardasset);
-            cardsByName.Add(cardasset.title, cardasset);
+            //Debug.Log("loading card " + cardasset.cardID + ", " + cardasset.title);
+            if (!CheckForConflict(cardasset))
+            {
+                allCards.Add(cardasset.cardID, cardasset);
+                cardsByName.Add(cardasset.title, cardasset);
+            }
         }
+    }
+
+    private static bool CheckForConflict(CardData card)
+    {
+        if (allCards.ContainsKey(card.cardID))
+        {
+            CardData conflict = allCards[card.cardID];
+
+            string warning =
+                string.Format("Card {0} has conflicting ID with {1} (id {2}), skipping...",
+                card.title, conflict.title, card.cardID);
+
+            Debug.LogWarning(warning);
+            return true;
+        }
+        else if (cardsByName.ContainsKey(card.title))
+        {
+            string warning =
+                string.Format("Card {0} has conflicting name, {1} is already in use, skipping... ",
+                card.cardID, card.title);
+
+            Debug.LogWarning(warning);
+            return true;
+        }
+        return false;
     }
 
     /// <summary>

--- a/Assets/Scripts/Gear/GearDatabase.cs
+++ b/Assets/Scripts/Gear/GearDatabase.cs
@@ -105,7 +105,13 @@ public static class GearDatabase
     {
         if (allGear.ContainsKey(gear.gearID))
         {
-            Debug.LogWarning("Ignoring duplicate key gear id:" + gear.gearID);
+            GearData conflict = allGear[gear.gearID];
+
+            string warning =
+                string.Format("Gear '{0}' has conflicting ID with '{1}' (id {2}), skipping...",
+                gear.gearName, conflict.gearName, gear.gearID);
+
+            Debug.LogWarning(warning);
             return;
         }
 


### PR DESCRIPTION
Necessary to prevent the game from refusing to start when cards exist with conflicting IDs or Names